### PR TITLE
fix(mask): bug if decimalMarker not locale default

### DIFF
--- a/projects/ngx-mask-lib/src/lib/mask.directive.ts
+++ b/projects/ngx-mask-lib/src/lib/mask.directive.ts
@@ -527,13 +527,15 @@ export class MaskDirective implements ControlValueAccessor, OnChanges, Validator
 			// eslint-disable-next-line no-param-reassign
 			inputValue = this._maskService.numberToString(inputValue);
 			if (!Array.isArray(this.decimalMarker)) {
+				const localeDecimalMarker = (1.1).toLocaleString().substring(1, 2);
 				// eslint-disable-next-line no-param-reassign
 				inputValue =
-					this.decimalMarker !== '.' ? inputValue.replace('.', this.decimalMarker) : inputValue;
+					this.decimalMarker !== localeDecimalMarker
+						? inputValue.replace(localeDecimalMarker, this.decimalMarker)
+						: inputValue;
 			}
 			this._maskService.isNumberValue = true;
 		}
-
 		if (typeof inputValue !== 'string') {
 			// eslint-disable-next-line no-param-reassign
 			inputValue = '';

--- a/src/app/showcase/showcase.component.html
+++ b/src/app/showcase/showcase.component.html
@@ -21,6 +21,57 @@
 			<div class="mat-card-wr">
 				<mat-card>
 					<mat-card-header>
+						<mat-card-title>Decimal separator with existing value</mat-card-title>
+						<mat-card-subtitle></mat-card-subtitle>
+					</mat-card-header>
+					<mat-card-content>
+						<div class="flex-row">
+							<div class="flex-cell-padding">
+								<mat-form-field>
+									<input
+										matInput
+										placeholder="Separator"
+										[dropSpecialCharacters]="true"
+										mask="separator.2"
+                    decimalMarker="."
+										[formControl]="initializedDecimalSeparatorForm"
+										[(ngModel)]="initializedDecimalSeparatorFormModel"
+									/>
+									<mat-hint><b>Mask: </b>separator.2, decimalMarker '.'</mat-hint>
+								</mat-form-field>
+							</div>
+							<div class="flex-cell">
+								<p>
+									<b>FormControl:</b>
+									{{
+										initializedDecimalSeparatorForm.value
+											? initializedDecimalSeparatorForm.value
+											: 'Empty'
+									}}
+								</p>
+								<p>
+									<b>NgModel:</b>
+									{{
+										initializedDecimalSeparatorFormModel
+											? initializedDecimalSeparatorFormModel
+											: 'Empty'
+									}}
+								</p>
+							</div>
+						</div>
+					</mat-card-content>
+				</mat-card>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="container">
+	<div class="row">
+		<div class="col-12">
+			<div class="mat-card-wr">
+				<mat-card>
+					<mat-card-header>
 						<mat-card-title>Mask common case</mat-card-title>
 						<mat-card-subtitle>Secure Input</mat-card-subtitle>
 					</mat-card-header>

--- a/src/app/showcase/showcase.component.ts
+++ b/src/app/showcase/showcase.component.ts
@@ -51,6 +51,8 @@ export class ShowcaseComponent {
 
 	public emptyMaskForm: FormControl;
 
+	public initializedDecimalSeparatorForm: FormControl;
+
 	public separatorForm: FormControl;
 
 	public percent: FormControl;
@@ -112,6 +114,8 @@ export class ShowcaseComponent {
 	public customPatternFormModel!: SN;
 
 	public separatorFormModel!: SN;
+
+	public initializedDecimalSeparatorFormModel = 1234.56;
 
 	public separatorPrecisionSeparatorFormModel!: SN;
 
@@ -184,6 +188,7 @@ export class ShowcaseComponent {
 		this.repeatForm = new FormControl('');
 		this.emptyMaskForm = new FormControl('');
 		this.separatorForm = new FormControl('');
+		this.initializedDecimalSeparatorForm = new FormControl('');
 		this.separatorPrecisionSeparatorForm = new FormControl('');
 		this.separatorZeroPrecisionSeparatorForm = new FormControl('');
 		this.dotSeparatorForm = new FormControl('');


### PR DESCRIPTION
note: manually tested with added showcase
"Decimal separator with existing value"

to test: set browser locale to German (so decimal marker defaults to ',')

before fix: 1234.56 shows as 1234.5
after fix: 1234.56 shows as 1234.56

if someone finds a way to mock the locale,
I'll gladly add a unit test for that

kept the fix to the minimum, no refactoring

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/JsDaddy/ngx-mask/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

NOTE: no unit tests, couldn't find a way to mock browser locale (would require DE for instance, so that the locale's decimal marker is ','

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

With browser locale to German (so decimal marker defaults to ',')
before fix: model form value of 1234.56 shows as 1234.5 in the form

Issue Number: might be related to 1009 or 1015

## What is the new behavior?

after fix: 1234.56 shows as 1234.56

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

if someone finds a way to mock the locale,
I'll gladly add a unit test for that
